### PR TITLE
Report the correct result if the "server" service is not running

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,13 @@ module.exports = () => {
 		return Promise.resolve(false);
 	}
 
-	// http://stackoverflow.com/a/11995662/64949
-	return execa('net.exe', ['session']).then(() => true).catch(() => false);
+	// http://stackoverflow.com/a/21295806/1641422
+	return execa('fsutil', ['dirty', 'query', '%systemdrive%']).then(() => true).catch(error => {
+		if (error.code === 'ENOENT') {
+			// http://stackoverflow.com/a/28268802
+			return execa('fltmc', []).then(() => true).catch(() => false);
+		}
+
+		return false;
+	});
 };


### PR DESCRIPTION
If the "server" service is not running, this module will report `false`
even when the user is the administrator.

By investigating further, `net.exe session` fails with the following
message:

```
The Server service is not started.

More help is available by typing NET HELPMSG 2114.
```

which is caught by the `.catch()` block, which returns `false` without
inspecting the error object.

The main issue is that `net.exe session` returns an exit code 2 both
when the user has no permissions and when the server service is not
running, making it impossibly to distinguish between both scenarios
without inspecting the output of the command.

The StackOverflow question linked from the source code addresses this
concern in another answer, by proposing the use of the following
command:

```
fsutil dirty query %systemdrive% >nul
```

`fsutil` is ensured to be present on Windows XP and later, and returns
an exit code 0 if the user is the administrator, and exit code 1
otherwise.

This commit introduces the recommended `fsutil` command, and falls back
to an `fltmc` approach discussed on the same thread if `fsutil` doesn't
exist (e.g: we get `ENOENT` for it).

Fixes: https://github.com/sindresorhus/is-admin/issues/3
See: http://stackoverflow.com/a/21295806/1641422
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>